### PR TITLE
Solve issue with missing headers for release.

### DIFF
--- a/RNSearchBar.xcodeproj/project.pbxproj
+++ b/RNSearchBar.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
This solves issue #12 

The problem was caused by header search paths not including React libraries for release build.