### PR TITLE
fix a bug that the search bar can not work in react native 0.9.0

### DIFF
--- a/RNSearchBar.m
+++ b/RNSearchBar.m
@@ -10,6 +10,7 @@
 @implementation RNSearchBar
 {
   RCTEventDispatcher *_eventDispatcher;
+  NSInteger _nativeEventCount;
 }
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
@@ -25,17 +26,22 @@
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
 {
   [self setShowsCancelButton:YES animated:YES];
-  
+    
+    
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
                                  reactTag:self.reactTag
-                                     text:searchBar.text];
+                                     text:searchBar.text
+                            eventCount:_nativeEventCount];
 }
 
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
 {
+    _nativeEventCount++;
+    
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeChange
                                  reactTag:self.reactTag
-                                     text:searchText];
+                                     text:searchText
+                               eventCount:_nativeEventCount];
 }
 
 - (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ios"
   ],
   "dependencies": {
-    "react-native": "^0"
+    "react-native": "^0.9.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I found the search-bar cannot work in React Native 0.9.0, as in the issue:
https://github.com/umhan35/react-native-search-bar/issues/15

Inspired by RCTTextField.m, I modified RNSearchBar.m to make it able to work.
Then I realized that it may not work under 0.9.0, hence I changed the package.json.

