### PR TITLE
fix link error in ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There is also an example project in the [SearchBarExample](SearchBarExample) dir
 ## Contribution
 
 For now, implemented are only some of the features of [UISearchBar](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UISearchBar_Class/).
-Feel free to send a pull request. To get started, you can read the ["Native UI Components (iOS)"](http://facebook.github.io/react-native/docs/nativecomponentsios.html) guide on React Native website.
+Feel free to send a pull request. To get started, you can read the ["Native UI Components (iOS)"](http://facebook.github.io/react-native/docs/native-components-ios.html) guide on React Native website.
 
 ## License
 


### PR DESCRIPTION
the `Native UI Components (iOS)` link in readme is broken