### PR TITLE
Cancel button animation state and translation support

### DIFF
--- a/RNSearchBar.h
+++ b/RNSearchBar.h
@@ -5,5 +5,8 @@
 @interface RNSearchBar : UISearchBar
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
+- (void)setCancelButtonText:(NSString *)text;
+- (void)setUseCancelButton:(BOOL)state;
+- (void)setCancelButtonUsesAnimation:(BOOL)state;
 
 @end

--- a/RNSearchBar.m
+++ b/RNSearchBar.m
@@ -13,6 +13,25 @@
   NSInteger _nativeEventCount;
 }
 
+NSString *cancelButtonText = nil;
+BOOL useCancelButton = NO;
+BOOL cancelButtonUsesAnimation = YES;
+
+- (void)setCancelButtonText:(NSString *)text
+{
+    cancelButtonText = text;
+}
+
+- (void)setUseCancelButton:(BOOL)state
+{
+    useCancelButton = state;
+}
+
+- (void)setCancelButtonUsesAnimation:(BOOL)state
+{
+    cancelButtonUsesAnimation = state;
+}
+
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
 {
   if ((self = [super initWithFrame:CGRectMake(0, 0, 1000, 44)])) {
@@ -34,7 +53,16 @@
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
 {
-  [self setShowsCancelButton:self.showsCancelButton animated:YES];
+  if (useCancelButton) {
+    [self setShowsCancelButton:YES animated:cancelButtonUsesAnimation];
+    if (cancelButtonText) {
+      for (UIView *subView in [[searchBar.subviews objectAtIndex:0] subviews]){
+        if([subView isKindOfClass:[UIButton class]]){
+          [(UIButton*)subView setTitle:cancelButtonText forState:UIControlStateNormal];
+        }
+      }
+    }
+  }
 
 
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
@@ -69,7 +97,7 @@
 {
   self.text = @"";
   [self resignFirstResponder];
-  [self setShowsCancelButton:NO animated:YES];
+  [self setShowsCancelButton:NO animated:cancelButtonUsesAnimation];
 
   NSDictionary *event = @{
                           @"target": self.reactTag,

--- a/RNSearchBar.m
+++ b/RNSearchBar.m
@@ -56,6 +56,7 @@ BOOL cancelButtonUsesAnimation = YES;
   if (useCancelButton) {
     [self setShowsCancelButton:YES animated:cancelButtonUsesAnimation];
     if (cancelButtonText) {
+      // http://stackoverflow.com/questions/2536151/how-to-change-the-default-text-of-cancel-button-which-appears-in-the-uisearchbar
       for (UIView *subView in [[searchBar.subviews objectAtIndex:0] subviews]){
         if([subView isKindOfClass:[UIButton class]]){
           [(UIButton*)subView setTitle:cancelButtonText forState:UIControlStateNormal];

--- a/RNSearchBarManager.m
+++ b/RNSearchBarManager.m
@@ -38,6 +38,21 @@ RCT_CUSTOM_VIEW_PROPERTY(hideBackground, BOOL, RNSearchBar)
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(cancelButtonText, NSString, RNSearchBar)
+{
+    [view setCancelButtonText:[RCTConvert NSString:json]];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(useCancelButton, BOOL, RNSearchBar)
+{
+    [view setUseCancelButton:[RCTConvert BOOL:json]];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(cancelButtonUsesAnimation, BOOL, RNSearchBar)
+{
+    [view setCancelButtonUsesAnimation:[RCTConvert BOOL:json]];
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(textFieldBackgroundColor, UIColor, RNSearchBar)
 {
   if ([RCTConvert UIColor:json]) {


### PR DESCRIPTION
BREAKING CHANGES!
My suggestion is to use separate property to enable cancel button (`useCancelButton`, defaults to false)
which, when enabled, will trigger cancel button visible when search bar is active and hidden otherwise.

Also one can use `cancelButtonText` (defaults to "Cancel") to alter button caption (fixes #38 ?)
and `cancelButtonUsesAnimation` (default to true) to enable or disable animation
while showing/hiding cancel button.

So, I think native view's property `showsCancelButton` can be deprecated and then removed (maybe fixes #34 ?)

P.S. I'm new to ObjectiveC, please, check carefully.