### PR TITLE
Expose UISearchBar barStyle and searchBarStyle properties

### DIFF
--- a/RNSearchBarManager.m
+++ b/RNSearchBarManager.m
@@ -5,6 +5,23 @@
 #import "RCTBridge.h"
 #import "RCTUIManager.h"
 
+@implementation RCTConvert (UIBarStyle)
+RCT_ENUM_CONVERTER(UIBarStyle, (@{
+                                  @"default": @(UIBarStyleDefault),
+                                  @"black": @(UIBarStyleBlack)
+                                  }),
+                   UIBarStyleDefault, integerValue)
+@end
+
+@implementation RCTConvert (UISearchBarStyle)
+RCT_ENUM_CONVERTER(UISearchBarStyle, (@{
+                                        @"default": @(UISearchBarStyleDefault),
+                                        @"prominent": @(UISearchBarStyleProminent),
+                                        @"minimal": @(UISearchBarStyleMinimal)
+                                        }),
+                   UISearchBarStyleDefault, integerValue)
+@end
+
 @implementation RNSearchBarManager
 
 RCT_EXPORT_MODULE()
@@ -30,6 +47,8 @@ RCT_EXPORT_VIEW_PROPERTY(showsCancelButton, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(enablesReturnKeyAutomatically, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(barStyle, UIBarStyle)
+RCT_EXPORT_VIEW_PROPERTY(searchBarStyle, UISearchBarStyle)
 RCT_CUSTOM_VIEW_PROPERTY(hideBackground, BOOL, RNSearchBar)
 {
     if ([RCTConvert BOOL:json]) {

--- a/SearchBar.coffee
+++ b/SearchBar.coffee
@@ -25,6 +25,12 @@ SearchBar = React.createClass
     onCancelButtonPress: PropTypes.func
     enablesReturnKeyAutomatically: PropTypes.bool
     hideBackground: PropTypes.bool
+    barStyle: PropTypes.oneOf ['default', 'black']
+    searchBarStyle: PropTypes.oneOf ['default', 'prominent', 'minimal']
+
+  getDefaultProps: ->
+    barStyle: 'default'
+    searchBarStyle: 'default'
 
   _onChange: (e) ->
     @props.onChange? e

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -24,7 +24,15 @@ SearchBar = React.createClass({
     onSearchButtonPress: PropTypes.func,
     onCancelButtonPress: PropTypes.func,
     enablesReturnKeyAutomatically: PropTypes.bool,
-    hideBackground: PropTypes.bool
+    hideBackground: PropTypes.bool,
+    barStyle: PropTypes.oneOf(['default', 'black']),
+    searchBarStyle: PropTypes.oneOf(['default', 'prominent', 'minimal'])
+  },
+  getDefaultProps: function() {
+    return {
+      barStyle: 'default',
+      searchBarStyle: 'default'
+    };
   },
   _onChange: function(e) {
     var base, base1;
@@ -42,11 +50,11 @@ SearchBar = React.createClass({
       return typeof (base1 = this.props).onCancelButtonPress === "function" ? base1.onCancelButtonPress() : void 0;
     }
   },
-  blur: function(){
-    NativeModules.RNSearchBarManager.blur(React.findNodeHandle(this));
+  blur: function() {
+    return NativeModules.RNSearchBarManager.blur(React.findNodeHandle(this));
   },
-  focus: function(){
-    NativeModules.RNSearchBarManager.focus(React.findNodeHandle(this));
+  focus: function() {
+    return NativeModules.RNSearchBarManager.focus(React.findNodeHandle(this));
   },
   render: function() {
     return <RNSearchBar


### PR DESCRIPTION
This makes it possible to set the [barStyle](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UISearchBar_Class/index.html#//apple_ref/occ/instp/UISearchBar/barStyle) and [searchBarStyle](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UISearchBar_Class/index.html#//apple_ref/occ/instp/UISearchBar/searchBarStyle) properties on the native UISearchBar component.