### PR TITLE
use hideCancelButton over showsCancelButton

### DIFF
--- a/RNSearchBar.h
+++ b/RNSearchBar.h
@@ -4,6 +4,8 @@
 
 @interface RNSearchBar : UISearchBar
 
+@property (nonatomic) bool hideCancelButton;
+
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/RNSearchBar.m
+++ b/RNSearchBar.m
@@ -13,6 +13,8 @@
   NSInteger _nativeEventCount;
 }
 
+@synthesize hideCancelButton;
+
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
 {
   if ((self = [super initWithFrame:CGRectMake(0, 0, 1000, 44)])) {
@@ -35,8 +37,9 @@
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
 {
-  [self setShowsCancelButton:self.showsCancelButton animated:YES];
-
+    if(self.hideCancelButton == NO){
+        [self setShowsCancelButton:YES animated:YES];
+    }
 
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
                                  reactTag:self.reactTag

--- a/RNSearchBarManager.m
+++ b/RNSearchBarManager.m
@@ -41,6 +41,7 @@ RCT_EXPORT_MODULE()
   return searchBar;
 }
 
+RCT_EXPORT_VIEW_PROPERTY(hideCancelButton, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(text, NSString)
 RCT_EXPORT_VIEW_PROPERTY(showsCancelButton, BOOL)


### PR DESCRIPTION
to fix #71
with this pull, by default cancel button will show onFocus and hide on blur (which is the same behavior before merge #30)
user can use hideCancelButton={true} to prevent cancel button from showing