### PR TITLE
Fixed default searchText offset, and added unFocus function

### DIFF
--- a/RNSearchBar.m
+++ b/RNSearchBar.m
@@ -18,7 +18,6 @@
   if ((self = [super initWithFrame:CGRectMake(0, 0, 1000, 44)])) {
     _eventDispatcher = eventDispatcher;
     self.delegate = self;
-    self.searchTextPositionAdjustment = UIOffsetMake(10, 0);
   }
   return self;
 }

--- a/RNSearchBar.m
+++ b/RNSearchBar.m
@@ -18,6 +18,7 @@
   if ((self = [super initWithFrame:CGRectMake(0, 0, 1000, 44)])) {
     _eventDispatcher = eventDispatcher;
     self.delegate = self;
+    self.searchTextPositionAdjustment = UIOffsetMake(10, 0);
   }
   return self;
 }

--- a/RNSearchBarManager.m
+++ b/RNSearchBarManager.m
@@ -121,5 +121,18 @@ RCT_EXPORT_METHOD(focus:(nonnull NSNumber *)reactTag)
      }];
 }
 
+RCT_EXPORT_METHOD(unFocus:(nonnull NSNumber *)reactTag)
+{
+  [self.bridge.uiManager addUIBlock:
+   ^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry){
+     RNSearchBar *searchBar = viewRegistry[reactTag];
+     
+     if ([searchBar isKindOfClass:[RNSearchBar class]]) {
+       [searchBar resignFirstResponder];
+     } else {
+       RCTLogError(@"Cannot unFocus: %@ (tag #%@) is not RNSearchBar", searchBar, reactTag);
+     }
+   }];
+}
 
 @end

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -57,6 +57,9 @@ SearchBar = React.createClass({
   focus: function() {
     return NativeModules.RNSearchBarManager.focus(ReactNative.findNodeHandle(this));
   },
+  unFocus: function() {
+    return NativeModules.RNSearchBarManager.unFocus(ReactNative.findNodeHandle(this));
+  },
   render: function() {
     return <RNSearchBar
       style={{height: NativeModules.RNSearchBarManager.ComponentHeight}}


### PR DESCRIPTION
This is a super helpful project! I've noticed a couple things that would make this easier to work with:

1)  The text offset was weird, so that the search text ended up being slap up against the search icon.  I changed this to a horizontal `UIOffset` of 10, which I think is closer to what it should normally look like.

2)  I wanted to have more fine grained control in the javascript over the whether the search bar was the first responder or not, so I could do things like this:

```
showsCancelButton={this.state.showsCancelButton}
onFocus={() => {
  this.setState({ showsCancelButton: true });
}}
onCancelButtonPress={() => {
  this.setState({ showsCancelButton: false });
  this.refs.searchBar.unFocus();
}}
onSearchButtonPress={() => {
  this.setState({ showsCancelButton: false });
  this.refs.searchBar.unFocus();
}}
```
This allows for behavior a lot more like, for example, the search bar on the second tab of Instagram's iOS app.  To do this, I added an `unFocus` method to the component.

What do you think?