### PR TITLE
fix cancelButton doesn't show on 2nd tap

### DIFF
--- a/RNSearchBar.h
+++ b/RNSearchBar.h
@@ -6,4 +6,6 @@
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 
+@property(nonatomic) BOOL _jsShowsCancelButton;
+
 @end

--- a/RNSearchBar.m
+++ b/RNSearchBar.m
@@ -29,13 +29,13 @@
                                        text:searchBar.text
                                         key:nil
                                  eventCount:_nativeEventCount];
-    
+
 }
 
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
 {
-  [self setShowsCancelButton:self.showsCancelButton animated:YES];
+  [self setShowsCancelButton:self._jsShowsCancelButton animated:YES];
 
 
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus

--- a/RNSearchBarManager.m
+++ b/RNSearchBarManager.m
@@ -43,7 +43,12 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(text, NSString)
-RCT_EXPORT_VIEW_PROPERTY(showsCancelButton, BOOL)
+RCT_CUSTOM_VIEW_PROPERTY(showsCancelButton, BOOL, RNSearchBar)
+{
+    BOOL value = [RCTConvert BOOL:json];
+    view._jsShowsCancelButton = value;
+    view.showsCancelButton = value;
+}
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(enablesReturnKeyAutomatically, BOOL)


### PR DESCRIPTION
@evollu @michaelhelvey Take a look. This will fix the bug but doesn't need `hideCancelButton` in #72