### PR TITLE
Update documentation and Fix viewOffset

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,25 @@ var SearchBar = require('react-native-search-bar');
 ```
 
 ### Managing the keyboard
-* Show - `this.refs.searchBar.focus()`;
-* Hide - `this.refs.searchBar.blur();`
-* Example
-	* Show the keyboard when the view loads
+* Show - `this.refs.searchBar.focus();`
+* Hide
+  - `this.refs.searchBar.blur();` - uses the iOS `endEditing:true` method on the underlying `UISearchBar` view.
+  - `this.refs.searchBar.unFocus();` - calls `resignFirstResponder` on the `UITextField` used by the `UISearchBar`.
+* Examples
+ * Show the keyboard when the view loads:
 ```javascript
 componentDidMount() {
-	this.refs.searchBar.focus();
+  this.refs.searchBar.focus();
 }
 ```
+ * Hide the keyboard when the user searches:
+```javascript
+...
+onSearchButtonPress={this.refs.searchBar.unFocus}
+...
+```
 
-For all supportted properties, please check out `propTypes` in either [SearchBar.coffee](SearchBar.coffee) or [SearchBar.js](SearchBar.js).
+For all supportted properties, please check out `propTypes` in [SearchBar.js](SearchBar.js).
 
 There is also an example project in the [SearchBarExample](SearchBarExample) directory.
 

--- a/RNSearchBarManager.m
+++ b/RNSearchBarManager.m
@@ -91,6 +91,7 @@ RCT_CUSTOM_VIEW_PROPERTY(textFieldBackgroundColor, UIColor, RNSearchBar)
     UIGraphicsEndImageContext();
 
     [view setSearchFieldBackgroundImage:image forState:UIControlStateNormal];
+    [view setSearchTextPositionAdjustment:UIOffsetMake(8.0, 0.0)];
   }
 }
 


### PR DESCRIPTION
@umhan35 This incorporates the clarifications to documentation you asked for in #81.

Note: I removed the reference to SearchBar.coffee in the docs, since this file doesn't seem to be in active development anymore, and now no longer reflects the current API.

I've also added the text offset for the `textFieldBackgroundColor` as mentioned in #69, but keeping the dimensions at `34` instead of changing them to `28`.