### PR TITLE
Added showCancelWhileEditing option

### DIFF
--- a/ios/RNSearchBar.h
+++ b/ios/RNSearchBar.h
@@ -7,11 +7,8 @@
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 
-<<<<<<< HEAD:ios/RNSearchBar.h
 @property(nonatomic) BOOL _jsShowsCancelButton;
 @property(nonatomic, copy) RCTBubblingEventBlock onSearchButtonPress;
 @property(nonatomic, copy) RCTBubblingEventBlock onCancelButtonPress;
 
-=======
->>>>>>> Added controlled cancel button:RNSearchBar.h
 @end

--- a/ios/RNSearchBar.h
+++ b/ios/RNSearchBar.h
@@ -7,8 +7,11 @@
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 
+<<<<<<< HEAD:ios/RNSearchBar.h
 @property(nonatomic) BOOL _jsShowsCancelButton;
 @property(nonatomic, copy) RCTBubblingEventBlock onSearchButtonPress;
 @property(nonatomic, copy) RCTBubblingEventBlock onCancelButtonPress;
 
+=======
+>>>>>>> Added controlled cancel button:RNSearchBar.h
 @end

--- a/ios/RNSearchBarManager.m
+++ b/ios/RNSearchBarManager.m
@@ -50,12 +50,6 @@ RCT_EXPORT_VIEW_PROPERTY(onSearchButtonPress, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCancelButtonPress, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(text, NSString)
-RCT_CUSTOM_VIEW_PROPERTY(showsCancelButton, BOOL, RNSearchBar)
-{
-    BOOL value = [RCTConvert BOOL:json];
-    view._jsShowsCancelButton = value;
-    view.showsCancelButton = value;
-}
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(enablesReturnKeyAutomatically, BOOL)
@@ -172,6 +166,20 @@ RCT_EXPORT_METHOD(clearText:(nonnull NSNumber *)reactTag)
              RCTLogError(@"Cannot clear text: %@ (tag #%@) is not RNSearchBar", searchBar, reactTag);
          }
      }];
+}
+
+RCT_EXPORT_METHOD(toggleCancelButton:(nonnull NSNumber *)reactTag  flag:(BOOL *)flag)
+{
+  [self.bridge.uiManager addUIBlock:
+   ^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry){
+       RNSearchBar *searchBar = viewRegistry[reactTag];
+
+       if ([searchBar isKindOfClass:[RNSearchBar class]]) {
+           [searchBar setShowsCancelButton:flag ? YES : NO animated:YES];
+       } else {
+           RCTLogError(@"Cannot toggle: %@ (tag #%@) is not RNSearchBar", searchBar, reactTag);
+       }
+   }];
 }
 
 @end

--- a/ios/RNSearchBarManager.m
+++ b/ios/RNSearchBarManager.m
@@ -50,6 +50,11 @@ RCT_EXPORT_VIEW_PROPERTY(onSearchButtonPress, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCancelButtonPress, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(text, NSString)
+RCT_CUSTOM_VIEW_PROPERTY(showsCancelButton, BOOL, RNSearchBar)
+{
+  BOOL value = [RCTConvert BOOL:json];
+  view.showsCancelButton = value;
+}
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(enablesReturnKeyAutomatically, BOOL)

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -73,6 +73,12 @@ class SearchBar extends React.PureComponent {
   unFocus() {
     return NativeModules.RNSearchBarManager.unFocus(findNodeHandle(this))
   }
+  
+  componentDidUpdate (prevProps) {
+    if (prevProps.showsCancelButton !== this.props.showsCancelButton) {
+      NativeModules.RNSearchBarManager.toggleCancelButton(findNodeHandle(this), this.props.showsCancelButton);
+    }
+  }
 
   render() {
     return (


### PR DESCRIPTION
I have added a new option `showCancelWhileEditing` where by even if you force `showsCancelButton` to `false`, you can still make cancel button to appear when user is typing in the Search Text Field.

I have also made sure that `searchBarCancelButtonClicked` will show or hide cancel button taking the value from `_jsShowsCancelButton` and not force it to `NO`
