### PR TITLE
.npmignore ignore example

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+SearchBarExample


### PR DESCRIPTION
prevent loading SearchBarExample on ```npm install```