### PR TITLE
Allow Keyboard.dismiss to dismiss the keyboard

### DIFF
--- a/SearchBar.coffee
+++ b/SearchBar.coffee
@@ -1,5 +1,6 @@
 React = require 'react'
 ReactNative = require 'react-native'
+TextInputState = require 'react-native/Libraries/Components/TextInput/TextInputState'
 
 RNSearchBar = ReactNative.requireNativeComponent 'RNSearchBar', null
 
@@ -47,6 +48,18 @@ SearchBar = React.createClass
     else if button == 'cancel'
       @props.onCancelButtonPress?()
 
+  _onFocus: () ->
+    handle = ReactNative.findNodeHandle(this)
+    TextInputState._currentlyFocusedID = handle
+    @props.onFocus? e.nativeEvent.text
+
+  _onBlur: () ->
+    TextInputState._currentlyFocusedID = null
+    @props.onBlur? e.nativeEvent.text
+
+  _setCurrentlyFocused: (viewID) ->
+    TextInputState._currentlyFocusedID = viewID
+
   blur: ->
     NativeModules.RNSearchBarManager.blur ReactNative.findNodeHandle(this)
 
@@ -62,6 +75,8 @@ SearchBar = React.createClass
       onChange={this._onChange}
       onPress={this._onPress}
       {...this.props}
+      onFocus={this._onFocus}
+      onBlur={this._onBlur}
     />`
 
 module.exports = SearchBar


### PR DESCRIPTION
Hook into RNs `TextInputState` so that calling `Keyboard.dismiss()` will also
dismiss they keyboard when you are serching.

This is slightly a hack since we're using a private API, but seems fairly stable
since this implementation has been stable since the initial commit:
https://github.com/facebook/react-native/blob/a15603d8f1ecdd673d80be318293cee53eb4475d/Libraries/Components/TextInput/TextInputState.js

The way this works is that when you call `Keyboard.dismiss()`, it eventually
calls `TextInputState.blurTextInput` with the currently focused field, which is
retrieved from `TextInputState._currentlyFocusedID`, and calls through to the
`UIManager`s `blur` method, which calls `resignFirstResponder` on the view.
https://github.com/facebook/react-native/blob/9ee815f6b52e0c2417c04e5a05e1e31df26daed2/React/Modules/RCTUIManager.m#L1060

This _does not_ call `RNSearchBarManager`s `blur` method, but since all that
does is call `endEditing` it seems to work equivalently so this seems
acceptable.