### PR TITLE
Accessibility tweak when hitting search button

### DIFF
--- a/RNSearchBar.m
+++ b/RNSearchBar.m
@@ -65,6 +65,7 @@
                           };
 
   [_eventDispatcher sendInputEventWithName:@"press" body:event];
+  UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, searchBar);
 }
 
 


### PR DESCRIPTION
This is a tweak for accessibility so that when the user hits the Search button in the keyboard, focus goes back to the search box, similar to what Apple does for accessibility in their apps.