### PR TITLE
Deprecate React.createClass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 xcuserdata
 *.js.map
+node_modules

--- a/SearchBar.coffee
+++ b/SearchBar.coffee
@@ -1,5 +1,6 @@
 React = require 'react'
 ReactNative = require 'react-native'
+createReactClass = require 'create-react-class'
 
 RNSearchBar = ReactNative.requireNativeComponent 'RNSearchBar', null
 
@@ -8,7 +9,7 @@ PropTypes = React.PropTypes
 NativeModules = ReactNative.NativeModules
 
 
-SearchBar = React.createClass
+SearchBar = createReactClass
 
   propTypes:
     placeholder: PropTypes.string

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -1,4 +1,4 @@
-var NativeModules, PropTypes, RNSearchBar, React, ReactNative, SearchBar;
+var NativeModules, PropTypes, RNSearchBar, React, ReactNative, SearchBar, createReactClass;
 
 React = require('react');
 
@@ -10,7 +10,9 @@ PropTypes = React.PropTypes;
 
 NativeModules = ReactNative.NativeModules;
 
-SearchBar = React.createClass({
+createReactClass = require('create-react-class');
+
+SearchBar = createReactClass({
   propTypes: {
     placeholder: PropTypes.string,
     text: PropTypes.string,

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   },
   "homepage": "https://github.com/umhan35/react-native-search-bar",
   "main": "SearchBar.js",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "create-react-class": "^15.6.0"
+  }
 }


### PR DESCRIPTION
React 0.15.5 deprecated `React.createClass` and will be removed completely in a newer version of react. Since react-native@0.45, this now shows as an error when the apps are running. https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings

The React team has provided a drop-in replacement for `React.createClass` as a separate library called "create-react-class".

This PR replaces `React.createClass` with `createReactClass`