### PR TITLE
Deprecate React.PropTypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 xcuserdata
 *.js.map
+node_modules

--- a/SearchBar.coffee
+++ b/SearchBar.coffee
@@ -1,9 +1,8 @@
 React = require 'react'
 ReactNative = require 'react-native'
+PropTypes = require 'prop-types'
 
 RNSearchBar = ReactNative.requireNativeComponent 'RNSearchBar', null
-
-PropTypes = React.PropTypes
 
 NativeModules = ReactNative.NativeModules
 

--- a/SearchBar.js
+++ b/SearchBar.js
@@ -6,7 +6,7 @@ ReactNative = require('react-native');
 
 RNSearchBar = ReactNative.requireNativeComponent('RNSearchBar', null);
 
-PropTypes = React.PropTypes;
+PropTypes = require('prop-types');
 
 NativeModules = ReactNative.NativeModules;
 

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   },
   "homepage": "https://github.com/umhan35/react-native-search-bar",
   "main": "SearchBar.js",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "SearchBar.js",
   "license": "MIT",
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
     "create-react-class": "^15.6.0"
   }
 }


### PR DESCRIPTION
React 0.15.5 deprecated `React.PropTypes` and will be removed completely in a newer version of react. Since react-native@0.45, this now shows as an error when the apps are running. https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings

The React team has provided a drop-in replacement for `React.PropTypes` as a separate library called "prop-types".

This PR replaces `React.PropTypes` with `prop-types`