### PR TITLE
Better handle cancel button internally

### DIFF
--- a/ios/RNSearchBarManager.m
+++ b/ios/RNSearchBarManager.m
@@ -52,8 +52,8 @@ RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(text, NSString)
 RCT_CUSTOM_VIEW_PROPERTY(showsCancelButton, BOOL, RNSearchBar)
 {
-  BOOL value = [RCTConvert BOOL:json];
-  view.showsCancelButton = value;
+    BOOL value = [RCTConvert BOOL:json];
+    view.showsCancelButton = value;
 }
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -45,6 +45,7 @@ class SearchBar extends React.PureComponent {
     searchBarStyle: PropTypes.oneOf(['default', 'prominent', 'minimal']),
     editable: PropTypes.bool,
     returnKeyType: PropTypes.string,
+    showsCancelButtonWhileEditing: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -66,6 +67,7 @@ class SearchBar extends React.PureComponent {
     autoCapitalize: 'sentences',
     autoCorrect: false,
     spellCheck: false,
+    showsCancelButtonWhileEditing: true,
     onChange: () => null,
     onChangeText: () => null,
     onFocus: () => null,
@@ -80,7 +82,35 @@ class SearchBar extends React.PureComponent {
   }
 
   onSearchButtonPress = (e) => {
+    if (this.props.showsCancelButtonWhileEditing) {
+      NativeModules.RNSearchBarManager.toggleCancelButton(findNodeHandle(this), true)
+    }
+
     this.props.onSearchButtonPress(e.nativeEvent.searchText)
+  }
+
+  onFocus = () => {
+    if (this.props.showsCancelButtonWhileEditing) {
+      NativeModules.RNSearchBarManager.toggleCancelButton(findNodeHandle(this), true)
+    }
+
+    this.props.onFocus()
+  }
+
+  onCancelButtonPress = () => {
+    if (this.props.showsCancelButtonWhileEditing) {
+      NativeModules.RNSearchBarManager.toggleCancelButton(findNodeHandle(this), false)
+    }
+
+    this.props.onCancelButtonPress()
+  }
+
+  onBlur = () => {
+    if (this.props.showsCancelButtonWhileEditing) {
+      NativeModules.RNSearchBarManager.toggleCancelButton(findNodeHandle(this), false)
+    }
+
+    this.props.onBlur()
   }
 
   blur() {
@@ -98,12 +128,6 @@ class SearchBar extends React.PureComponent {
   unFocus() {
     return NativeModules.RNSearchBarManager.unFocus(findNodeHandle(this))
   }
-  
-  componentDidUpdate (prevProps) {
-    if (prevProps.showsCancelButton !== this.props.showsCancelButton) {
-      NativeModules.RNSearchBarManager.toggleCancelButton(findNodeHandle(this), this.props.showsCancelButton);
-    }
-  }
 
   render() {
     return (
@@ -112,8 +136,10 @@ class SearchBar extends React.PureComponent {
         {...this.props}
         onChange={this.onChange}
         onPress={this.onPress}
+        onFocus={this.onFocus}
+        onBlur={this.onBlur}
         onSearchButtonPress={this.onSearchButtonPress}
-        onCancelButtonPress={this.props.onCancelButtonPress}
+        onCancelButtonPress={this.onCancelButtonPress}
       />
     )
   }

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -102,6 +102,7 @@ class SearchBar extends React.PureComponent {
       NativeModules.RNSearchBarManager.toggleCancelButton(findNodeHandle(this), false)
     }
 
+    this.props.onChangeText('')
     this.props.onCancelButtonPress()
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,6 +47,13 @@ interface Props {
   showsCancelButton?: boolean
 
   /**
+   * Only shows the cancel button while the search bar has focus
+   * 
+   * Default is true
+   */
+  showsCancelButtonWhileEditing?: boolean
+
+  /**
    * Indicates whether the Return key is automatically enabled when the user is entering text.
    *
    * Default is true


### PR DESCRIPTION
Only shows the cancel button when the search bar has focus. No more hacks with setting state on focus needed
