### PR TITLE
Adds the cross-platform return keys

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,7 +4,7 @@
 // TypeScript Version: 2.6
 
 import * as React from 'react'
-import { ReturnKeyTypeIOS, KeyboardType, KeyboardTypeIOS, ViewStyle } from 'react-native'
+import { ReturnKeyType, ReturnKeyTypeIOS, KeyboardType, KeyboardTypeIOS, ViewStyle } from 'react-native'
 
 interface Props {
   /**
@@ -100,7 +100,7 @@ interface Props {
    *
    * Default is 'search'
    */
-  returnKeyType?: ReturnKeyTypeIOS
+  returnKeyType?: ReturnKeyType | ReturnKeyTypeIOS
 
   /**
    * The type of keyboard to display


### PR DESCRIPTION
Adds the typescript definition for the "cross platform return key types. These are: `"done" | "go" | "next" | "search" | "send"`.