### PR TITLE
Add setText instance method

### DIFF
--- a/ios/RNSearchBarManager.m
+++ b/ios/RNSearchBarManager.m
@@ -182,6 +182,20 @@ RCT_EXPORT_METHOD(clearText:(nonnull NSNumber *)reactTag)
      }];
 }
 
+RCT_EXPORT_METHOD(setText:(nonnull NSNumber *)reactTag text:(NSString *)text)
+{
+    [self.bridge.uiManager addUIBlock:
+     ^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry){
+         RNSearchBar *searchBar = viewRegistry[reactTag];
+
+         if ([searchBar isKindOfClass:[RNSearchBar class]]) {
+             [searchBar setText:text];
+         } else {
+             RCTLogError(@"Cannot set text: %@ (tag #%@) is not RNSearchBar", searchBar, reactTag);
+         }
+     }];
+}
+
 RCT_EXPORT_METHOD(toggleCancelButton:(nonnull NSNumber *)reactTag  flag:(BOOL *)flag)
 {
   [self.bridge.uiManager addUIBlock:

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -182,4 +182,5 @@ export default class SearchBar extends React.Component<Props> {
   blur(): void
   unFocus(): void
   clearText(): void
+  setText(): void
 }


### PR DESCRIPTION
This adds a `setText` instance method to the search bar.

I'm using this to fill text into my search when the user taps a previous search result from my list that I maintain separately.

Problems? Nitpicks? Let me know!