### PR TITLE
implement view property `glassIconColor` to override the icons default color

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,11 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion = safeExtGet('buildToolsVersion', "28.0.3")
+    defaultConfig {
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
+    }
 
     compileOptions {
         sourceCompatibility = '1.8'

--- a/ios/RNSearchBarManager.m
+++ b/ios/RNSearchBarManager.m
@@ -130,6 +130,28 @@ RCT_CUSTOM_VIEW_PROPERTY(textColor, UIColor, RNSearchBar)
              };
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(glassIconColor, UIColor, RNSearchBar)
+{
+    if([RCTConvert UIColor:json]) {
+        @try {
+            UITextField* textField = [view valueForKey: @"searchField"];
+            if (!textField) {
+                return;
+            }
+
+            UIView* glassIconView = textField.leftView;
+            if (!glassIconView) {
+                return;
+            }
+
+            glassIconView.tintColor = [RCTConvert UIColor:json];
+        }
+        @catch (NSException *exception) {
+           NSLog(@"%@", exception.reason);
+        }
+    }
+}
+
 RCT_EXPORT_METHOD(blur:(nonnull NSNumber *)reactTag)
 {
     [self.bridge.uiManager addUIBlock:


### PR DESCRIPTION
We recently saw issues with the icon color in the search bar when using a device on ios 13 in dark mode. In our case the issue seems to be caused by overriding the `textFieldBackgroundColor` to white, which does not match the ios dark mode theming but it's a requirement of our app designs.

I think if there is an api to override the backgroundColor, than it makes sense to have an api to override the icon color as well. @umhan35 @iRoachie 

![Screenshot 2020-05-11 at 13 37 03](https://user-images.githubusercontent.com/5617793/81557640-99027100-938c-11ea-8e7a-0aa1d1b96abf.png)
