### PR TITLE
fix android build errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,11 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion = safeExtGet('buildToolsVersion', "28.0.3")
+    defaultConfig {
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
+    }
 
     compileOptions {
         sourceCompatibility = '1.8'


### PR DESCRIPTION
I was facing build errors on my local machine and on linux ci.

```
Task :react-native-search-bar:processDebugAndroidTestManifest FAILED
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-search-bar:processDebugAndroidTestManifest'.
> Manifest merger failed : uses-sdk:minSdkVersion 1 cannot be smaller than version 16 declared in library [com.facebook.react:react-native:0.62.2] /root/.gradle/caches/transforms-2/files-2.1/fb1b10f067852cd6c3178d2de46b96d8/AndroidManifest.xml as the library might be using APIs not available in 1
  	Suggestion: use a compatible library with a minSdk of at most 1,
  		or increase this project's minSdk version to at least 16,
  		or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
```

Setting a minSdkVersion in the library build.gradle fixed the issue. This also seems to be a best practice to avoid build issues. @umhan35 