### PR TITLE
Add appearance prop so you can force dark or light mode

### DIFF
--- a/RNSearchBar.podspec
+++ b/RNSearchBar.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source        = { :git => package["repository"]["url"] }
   s.requires_arc  = true
   s.preserve_paths= "package.json", "LICENSE"
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end

--- a/ios/RNSearchBarManager.m
+++ b/ios/RNSearchBarManager.m
@@ -123,6 +123,19 @@ RCT_CUSTOM_VIEW_PROPERTY(textColor, UIColor, RNSearchBar)
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(appearance, NSString, RNSearchBar) {
+    #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) &&      \
+        __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+        if (@available(iOS 13.0, *)) {
+            if ([appearanceString isEqual:@"dark"]) {
+                [UIBarButtonItem setOverrideUserInterfaceStyle:UIUserInterfaceStyleDark];
+            } else if ([appearanceString isEqual:@"light"]) {
+                [UIBarButtonItem setOverrideUserInterfaceStyle:UIUserInterfaceStyleLight];
+            }
+        }
+    #endif
+}
+
 - (NSDictionary *)constantsToExport
 {
     return @{

--- a/ios/RNSearchBarManager.m
+++ b/ios/RNSearchBarManager.m
@@ -124,16 +124,18 @@ RCT_CUSTOM_VIEW_PROPERTY(textColor, UIColor, RNSearchBar)
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(appearance, NSString, RNSearchBar) {
-    #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) &&      \
-        __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-        if (@available(iOS 13.0, *)) {
-            if ([appearanceString isEqual:@"dark"]) {
-                [UIBarButtonItem setOverrideUserInterfaceStyle:UIUserInterfaceStyleDark];
-            } else if ([appearanceString isEqual:@"light"]) {
-                [UIBarButtonItem setOverrideUserInterfaceStyle:UIUserInterfaceStyleLight];
+    if ([RCTConvert NSString:json]) {
+        #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) &&      \
+            __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+            if (@available(iOS 13.0, *)) {
+                if ([[RCTConvert NSString:json] isEqual:@"dark"]) {
+                    [view setOverrideUserInterfaceStyle:UIUserInterfaceStyleDark];
+                } else if ([[RCTConvert NSString:json] isEqual:@"light"]) {
+                    [view setOverrideUserInterfaceStyle:UIUserInterfaceStyleLight];
+                }
             }
-        }
-    #endif
+        #endif
+    }
 }
 
 - (NSDictionary *)constantsToExport

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -51,6 +51,7 @@ class SearchBar extends React.PureComponent {
     ]),
     autoCorrect: PropTypes.bool,
     spellCheck: PropTypes.bool,
+    appearance: PropTypes.string,
     barStyle: PropTypes.oneOf(['default', 'black']),
     searchBarStyle: PropTypes.oneOf(['default', 'prominent', 'minimal']),
     editable: PropTypes.bool,
@@ -87,12 +88,12 @@ class SearchBar extends React.PureComponent {
     onCancelButtonPress: () => null,
   };
 
-  onChange = e => {
+  onChange = (e) => {
     this.props.onChange(e);
     this.props.onChangeText(e.nativeEvent.text);
   };
 
-  onSearchButtonPress = e => {
+  onSearchButtonPress = (e) => {
     this.props.onSearchButtonPress(e.nativeEvent.searchText);
   };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -140,6 +140,13 @@ interface Props {
   spellCheck?: boolean;
 
   /**
+   * (iOS 13+ only)
+   *
+   * Overrides the control's appearance irrespective of the OS theme
+   */
+  appearance?: 'dark' | 'light';
+
+  /**
    * Event fired when
    */
   onChange?(event: { target: number; text: string; eventCount: number }): void;


### PR DESCRIPTION
If you have an app that only has a dark theme, you should be able to force the style of the search bar to always match dark.